### PR TITLE
Stop printing features during automatic run

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,5 +4,5 @@ After making changes, run the following checks:
 2. `cargo run -- --automatic`
    - ensure the battle progresses automatically and ends with either player or enemy defeated.
 
-The automatic log must list every available game feature at the start of play.
-Keep `GAME_FEATURES.md` updated whenever features change so the log remains accurate.
+Do not print the list of game features in the automatic log.
+Keep `GAME_FEATURES.md` updated whenever features change.

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,7 +100,9 @@ fn battle(player: &mut Character, enemy: &mut Character, automatic: bool) -> boo
 
 fn run_game(automatic: bool) {
     println!("Welcome to Rusty RPG!");
-    print_features();
+    if !automatic {
+        print_features();
+    }
     let mut player = Character {
         name: String::from("Hero"),
         hp: 30,


### PR DESCRIPTION
## Summary
- avoid logging game features when `--automatic` is used

## Testing
- `cargo check --offline`
- `cargo run -- --automatic`